### PR TITLE
feat: Integrate backend, configure solc, add README

### DIFF
--- a/xet-composer/README.md
+++ b/xet-composer/README.md
@@ -1,0 +1,68 @@
+# XET Composer
+
+XET Composer is a tool for composing and deploying Solidity smart contracts using a visual interface. It features a Rust backend for contract generation and deployment, and a Next.js frontend for user interaction.
+
+## Project Structure
+
+- `frontend/`: Next.js frontend application.
+- `backend/`: Rust backend application (Axum server).
+- `contracts/`: Solidity contract templates (`.sol.tera`) and vendorized libraries.
+  - `contracts/lib/openzeppelin-repo/`: Expected location for the vendorized OpenZeppelin contracts repository.
+- `deployments/`: Intended for storing deployment artifacts (not yet used).
+
+## Prerequisites
+
+- **Rust:** Version 1.78.0 or newer. Install via [rustup](https://rustup.rs/).
+- **Solidity Compiler (`solc`):** Required by the backend. Ensure it's installed and accessible. The backend can be configured to use a specific `solc` executable via the `SOLC_PATH` environment variable (defaults to `solc` if in system PATH).
+- **Node.js and npm:** For running the Next.js frontend. Install via [nvm](https://github.com/nvm-sh/nvm) or official installers.
+- **OpenZeppelin Contracts (Vendorized):**
+  - Clone or copy the [OpenZeppelin Contracts repository](https://github.com/OpenZeppelin/openzeppelin-contracts) into `xet-composer/contracts/lib/openzeppelin-repo/`.
+  - The backend is configured to find imports like `@openzeppelin/contracts/...` at `lib/openzeppelin-repo/contracts/...` relative to the `xet-composer/contracts/` directory.
+
+## Backend Setup & Run (Rust)
+
+1.  **Navigate to the backend directory:**
+    ```bash
+    cd xet-composer/backend/xet_composer_backend
+    ```
+
+2.  **Set `SOLC_PATH` (Optional):**
+    If `solc` is not in your system PATH, or you want to use a specific version:
+    ```bash
+    export SOLC_PATH=/path/to/your/solc
+    ```
+
+3.  **Run the backend server:**
+    ```bash
+    cargo run
+    ```
+    The server will start on `http://localhost:8000`.
+
+## Frontend Setup & Run (Next.js)
+
+1.  **Navigate to the frontend directory:**
+    ```bash
+    cd xet-composer/frontend
+    ```
+
+2.  **Install dependencies:**
+    ```bash
+    npm install
+    ```
+
+3.  **Run the frontend development server:**
+    ```bash
+    npm run dev
+    ```
+    The frontend will be accessible at `http://localhost:3000`.
+    It expects the backend to be running on `http://localhost:8000`.
+
+## Development Workflow
+
+1.  Ensure the OpenZeppelin contracts are vendorized as described in Prerequisites.
+2.  Start the backend server.
+3.  Start the frontend server.
+4.  Open `http://localhost:3000` in your browser.
+5.  Use the form to configure and "deploy" (currently compiles and simulates deployment) a contract.
+    - The `TokenVesting.sol.tera` template is available.
+    - Input parameters, including a valid ERC20 token address for the chain you intend to deploy to eventually, beneficiary address, start time, durations, and an initial owner.

--- a/xet-composer/backend/xet_composer_backend/src/deploy_engine.rs
+++ b/xet-composer/backend/xet_composer_backend/src/deploy_engine.rs
@@ -1,9 +1,9 @@
 use ethers::prelude::*; // Basic ethers types, actual deployment later
 use serde_json::Value;
 use std::process::{Command, Output};
-use std::path::Path;
+use std::path::Path; // Keep Path
 use std::fs;
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, Builder}; // Added Builder for tempdir
 use std::io::Write;
 
 // Error type for this module
@@ -13,13 +13,15 @@ pub enum DeployError {
     SolcError(String),
     EthersError(String), // Placeholder for actual ethers errors
     JsonError(serde_json::Error),
-    CompilationFailed(String),
+    CompilationFailed(String), // Kept this, but SolcError is more specific for compilation
     NoAbiFound(String),
     NoBytecodeFound(String),
+    TempDirError(std::io::Error), // For tempdir creation errors
 }
 
 impl From<std::io::Error> for DeployError {
     fn from(err: std::io::Error) -> DeployError {
+        // Differentiate tempdir errors if possible, or generalize
         DeployError::IoError(err)
     }
 }
@@ -31,9 +33,7 @@ impl From<serde_json::Error> for DeployError {
 }
 
 pub struct DeployEngine {
-    // In the future, this might hold an ethers client or signer.
-    // For now, it's stateless or holds configuration for solc.
-    solc_path: String, // Path to the solc executable
+    solc_executable: String, // Modified field name
 }
 
 #[derive(Debug, Clone)]
@@ -43,100 +43,93 @@ pub struct CompilationOutput {
 }
 
 impl DeployEngine {
-    pub fn new(solc_path: String) -> Self {
-        Self { solc_path }
+    pub fn new(solc_executable: String) -> Self { // Modified
+        Self { solc_executable }
     }
 
     /// Compiles a Solidity source string using solc CLI.
-    /// Expects `solc` to be available in the provided path.
-    /// `contract_name` should be the name of the contract to extract from solc output (e.g., "TokenVesting").
     pub fn compile_solidity(
         &self,
         solidity_source: &str,
         contract_name: &str,
+        base_path: &Path, // New parameter
+        remappings: &[String], // New parameter: e.g., "@openzeppelin/=lib/openzeppelin/"
     ) -> Result<CompilationOutput, DeployError> {
-        // Create a temporary file for the Solidity source
-        let mut temp_sol_file = NamedTempFile::new()?;
+        let mut temp_sol_file = NamedTempFile::new()?; // Handled by From<std::io::Error>
         temp_sol_file.write_all(solidity_source.as_bytes())?;
-        let temp_sol_path = temp_sol_file.path().to_str().unwrap();
+        let temp_sol_path = temp_sol_file.path();
 
-        // Run solc
-        let output = Command::new(&self.solc_path)
-            .arg("--abi")
-            .arg("--bin")
-            .arg("--optimize") // Optional: add optimization
-            .arg("-o")
-            .arg(".") // Output directory (current dir, files will be named like <contract_name>.abi/bin)
-            .arg(temp_sol_path)
-            .arg("--overwrite") // Allow overwriting output files
-            .output()?; // Get stdout/stderr
+        // Output directory for ABI and BIN files - use a temporary directory
+        let temp_out_dir = Builder::new().prefix("solc_out_").tempdir()
+            .map_err(DeployError::TempDirError)?; // Specific error for tempdir
+        let out_dir_path_str = temp_out_dir.path().to_str().unwrap_or_default(); // Handle potential None from to_str
+
+        let mut cmd = Command::new(&self.solc_executable);
+        cmd.arg("--abi")
+           .arg("--bin")
+           .arg("--optimize")
+           .arg("--overwrite") // Important for subsequent calls
+           .arg("-o")
+           .arg(out_dir_path_str) // Output to temp directory
+           .arg("--base-path")    // Add base-path
+           .arg(base_path)        // The actual base path
+           .arg(temp_sol_path);   // Input .sol file
+
+        // Add remappings
+        for remap in remappings {
+            cmd.arg(remap);
+        }
+        
+        let output = cmd.output()?; // Handled by From<std::io::Error>
 
         if !output.status.success() {
             return Err(DeployError::SolcError(format!(
-                "solc failed with status: {}
-stdout: {}
-stderr: {}",
+                "solc failed with status: {}\nstdout: {}\nstderr: {}",
                 output.status,
                 String::from_utf8_lossy(&output.stdout),
                 String::from_utf8_lossy(&output.stderr)
             )));
         }
 
-        // Read ABI and Bin files - solc creates them in the current directory
-        // or a specified output directory. Here, using "." means current dir.
-        // The files are typically named like ContractName.abi and ContractName.bin
-        // Adjust if solc version outputs differently or if using combined JSON.
-        // For simplicity, this assumes separate .abi and .bin files are generated in the CWD.
-        // A more robust approach is to use `solc --combined-json abi,bin` and parse that.
+        // Construct paths to ABI and BIN files within the temp output directory
+        let abi_file_path = temp_out_dir.path().join(format!("{}.abi", contract_name));
+        let bin_file_path = temp_out_dir.path().join(format!("{}.bin", contract_name));
 
-        let abi_file_path = format!("{}.abi", contract_name);
-        let bin_file_path = format!("{}.bin", contract_name);
-
-        let abi_str = fs::read_to_string(&abi_file_path)?;
-        let bytecode_hex = fs::read_to_string(&bin_file_path)?; // This is often just the hex string
-
-        // Clean up temporary files created by solc
-        fs::remove_file(&abi_file_path).ok(); // .ok() to ignore error if file not found
-        fs::remove_file(&bin_file_path).ok();
-        // Temp source file is removed when `temp_sol_file` goes out of scope.
-
-        let abi_json: Value = serde_json::from_str(&abi_str)?;
+        let abi_str = fs::read_to_string(&abi_file_path)
+            .map_err(|e| DeployError::NoAbiFound(format!("Could not read ABI file {:?}: {}", abi_file_path, e)))?;
+        let bytecode_hex = fs::read_to_string(&bin_file_path)
+            .map_err(|e| DeployError::NoBytecodeFound(format!("Could not read BIN file {:?}: {}", bin_file_path, e)))?;
+         
+        let abi_json: Value = serde_json::from_str(&abi_str)?; // Handled by From<serde_json::Error>
 
         Ok(CompilationOutput {
             abi: abi_json,
-            bytecode: bytecode_hex.trim().to_string(), // Trim whitespace/newline
+            bytecode: bytecode_hex.trim().to_string(),
         })
     }
     
     /// Placeholder for deploying a compiled contract.
-    /// This will be significantly expanded when ethers-rs is fully integrated.
     pub async fn deploy_contract(
         &self,
-        _abi: Value, // Will be ethers::abi::Abi
-        _bytecode: String, // Will be ethers::types::Bytes
-        _constructor_args: Option<Value>, // Parameters for the constructor
+        _abi: Value,
+        _bytecode: String,
+        _constructor_args: Option<Value>,
     ) -> Result<String, DeployError> {
-        // Simulate deployment
         println!("Simulating contract deployment...");
-        // In a real scenario:
-        // 1. Setup ethers provider & signer.
-        // 2. Create ContractFactory.
-        // 3. Deploy contract with constructor_args.
-        // 4. Wait for transaction confirmation.
-        // 5. Return contract address.
         Ok("0xSIMULATED_DEPLOYED_ADDRESS".to_string())
     }
 }
 
-// Example usage (will be integrated into main.rs later)
+// Example usage (commented out, for reference)
 /*
 async fn example_deploy() {
-    // Assume solc is in PATH or provide direct path
-    let engine = DeployEngine::new("solc".to_string()); 
+    let solc_exe = env::var("SOLC_PATH").unwrap_or_else(|_| "solc".to_string());
+    let engine = DeployEngine::new(solc_exe); 
     let source_code = r#"
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
-contract MyContract {
+import "@openzeppelin/contracts/utils/Context.sol"; // Example import
+contract MyContract is Context {
     uint public myNumber;
     constructor(uint _initialNumber) {
         myNumber = _initialNumber;
@@ -145,15 +138,17 @@ contract MyContract {
         myNumber = _newNumber;
     }
 }"#;
+    
+    // Define a base path (e.g., where your 'lib' or 'node_modules' might be if not in default include paths)
+    // For this example, assume 'contracts' is our base, and openzeppelin is in 'contracts/lib/openzeppelin-repo/contracts'
+    let base_contracts_dir = PathBuf::from("./"); // Or wherever your project root relative to execution is
+    let remappings = vec!["@openzeppelin/contracts/=lib/openzeppelin-repo/contracts/".to_string()];
 
-    match engine.compile_solidity(source_code, "MyContract") {
+    match engine.compile_solidity(source_code, "MyContract", &base_contracts_dir, &remappings) {
         Ok(comp_output) => {
             println!("ABI: {}", comp_output.abi.to_string());
             println!("Bytecode: {}", comp_output.bytecode);
             
-            // Simulate constructor args if any
-            // let constructor_args = Some(serde_json::json!([123])); 
-
             match engine.deploy_contract(comp_output.abi, comp_output.bytecode, None).await {
                 Ok(address) => println!("Deployed to: {}", address),
                 Err(e) => eprintln!("Deployment error: {:?}", e),

--- a/xet-composer/backend/xet_composer_backend/src/main.rs
+++ b/xet-composer/backend/xet_composer_backend/src/main.rs
@@ -1,57 +1,138 @@
 use axum::{routing::post, Router, Json};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::env; // Added for env::var
 
-mod sol_template_engine; // Added module
-mod deploy_engine; // Add this line
+// Existing module declarations
+mod sol_template_engine;
+mod deploy_engine;
 
-// Define the request structure for the /api/deploy endpoint
+// Use statements for our modules
+use sol_template_engine::{SolTemplateEngine, TemplateError};
+use deploy_engine::{DeployEngine, CompilationOutput, DeployError};
+
 #[derive(Deserialize, Debug)]
 struct DeployRequest {
-    contract: String,
-    params: serde_json::Value, // Using serde_json::Value for flexible parameters
+    contract: String, // e.g., "TokenVesting.sol.tera"
+    params: serde_json::Value,
 }
 
-// Define the response structure for the /api/deploy endpoint
 #[derive(Serialize, Debug)]
 struct DeployResult {
     success: bool,
     message: String,
-    contract_address: Option<String>,
-    abi: Option<serde_json::Value>, // ABI can be complex, so Value is suitable
+    contract_name: Option<String>,
+    contract_address: Option<String>, // Still simulated for now
+    abi: Option<serde_json::Value>,
+    bytecode: Option<String>,
 }
 
-// The handler for the /api/deploy endpoint
 async fn deploy_handler(Json(payload): Json<DeployRequest>) -> Json<DeployResult> {
-    // For now, this is a placeholder.
-    // Actual logic for template rendering, compilation, and deployment will be added later.
-    println!("Received deploy request for contract: {}", payload.contract);
+    println!("Received deploy request for contract template: {}", payload.contract);
     println!("Params: {:?}", payload.params);
 
-    // Simulate a successful deployment for now
-    Json(DeployResult {
-        success: true,
-        message: format!("Contract '{}' processed (simulated).", payload.contract),
-        contract_address: Some("0x1234567890abcdef1234567890abcdef12345678".to_string()),
-        abi: Some(serde_json::json!({"temp_abi": "coming_soon"})),
-    })
+    // --- Configuration ---
+    let contracts_base_dir = PathBuf::from("../../contracts") // Relative to executable in target/debug or if run from workspace root
+        .canonicalize()
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to canonicalize contracts_base_dir: {:?}. Using relative path.", e);
+            // Fallback: if canonicalize fails (e.g. dir doesn't exist yet in test env),
+            // provide a relative path. This might be okay if solc handles it.
+            PathBuf::from("../../contracts")
+        });
+    
+    println!("Using contracts base directory: {:?}", contracts_base_dir);
+
+    let solc_executable = env::var("SOLC_PATH").unwrap_or_else(|_| "solc".to_string());
+    println!("Using SOLC executable: {}", solc_executable);
+    
+    let solc_remappings = vec![
+        "@openzeppelin/contracts/=lib/openzeppelin-repo/contracts/".to_string(),
+        // Example: "ds-test/=lib/forge-std/lib/ds-test/src/"
+    ];
+    println!("Using SOLC remappings: {:?}", solc_remappings);
+
+
+    // Initialize engines
+    // SolTemplateEngine expects the path to the directory containing .sol.tera files.
+    let template_engine = match SolTemplateEngine::new(contracts_base_dir.clone()) {
+        Ok(engine) => engine,
+        Err(e) => {
+            eprintln!("Failed to initialize SolTemplateEngine: {:?}", e);
+            return Json(DeployResult {
+                success: false,
+                message: format!("Failed to initialize template engine: {:?}", e),
+                contract_name: None,
+                contract_address: None,
+                abi: None,
+                bytecode: None,
+            });
+        }
+    };
+
+    let deploy_engine = DeployEngine::new(solc_executable.clone());
+
+    // 1. Render the Solidity template
+    let rendered_solidity = match template_engine.render_template(&payload.contract, &payload.params) {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("Failed to render template {}: {:?}", payload.contract, e);
+            return Json(DeployResult {
+                success: false,
+                message: format!("Failed to render template '{}': {:?}", payload.contract, e),
+                contract_name: None,
+                contract_address: None,
+                abi: None,
+                bytecode: None,
+            });
+        }
+    };
+
+    let contract_name_to_compile = payload.contract.replace(".sol.tera", "");
+
+    // 2. Compile the rendered Solidity
+    // Pass the contracts_base_dir as the base_path for solc.
+    match deploy_engine.compile_solidity(&rendered_solidity, &contract_name_to_compile, &contracts_base_dir, &solc_remappings) {
+        Ok(comp_output) => {
+            println!("Compilation successful for {}", contract_name_to_compile);
+            // Deployment is still simulated.
+            Json(DeployResult {
+                success: true,
+                message: format!("Contract '{}' compiled successfully (deployment simulated).", contract_name_to_compile),
+                contract_name: Some(contract_name_to_compile),
+                contract_address: Some("0xSIMULATED_ADDRESS_AFTER_COMPILE_AND_REMAP".to_string()), // Updated placeholder
+                abi: Some(comp_output.abi),
+                bytecode: Some(comp_output.bytecode),
+            })
+        }
+        Err(e) => {
+            eprintln!("Failed to compile Solidity for {}: {:?}", contract_name_to_compile, e);
+            let error_message = match e {
+                DeployError::SolcError(solc_err) => format!("Solidity compilation failed: {}", solc_err),
+                DeployError::NoAbiFound(path_err) => format!("ABI file not found after compilation: {}", path_err),
+                DeployError::NoBytecodeFound(path_err) => format!("Bytecode file not found after compilation: {}", path_err),
+                _ => format!("Solidity compilation failed: {:?}", e),
+            };
+            Json(DeployResult {
+                success: false,
+                message: error_message,
+                contract_name: Some(contract_name_to_compile),
+                contract_address: None,
+                abi: None,
+                bytecode: None,
+            })
+        }
+    }
 }
 
 #[tokio::main]
 async fn main() {
-    // Define the application routes
-    let app = Router::new()
-        .route("/api/deploy", post(deploy_handler));
-
-    // Define the server address
+    let app = Router::new().route("/api/deploy", post(deploy_handler));
     let addr = SocketAddr::from(([127, 0, 0, 1], 8000));
     println!("Backend server listening on {}", addr);
 
-    // Run the server
-    if let Err(e) = axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-    {
+    if let Err(e) = axum::Server::bind(&addr).serve(app.into_make_service()).await {
         eprintln!("Server error: {}", e);
     }
 }


### PR DESCRIPTION
Integrates the template engine and deployment (compilation) engine into the main Axum request handler in the backend.

Key changes:
- Backend:
  - `main.rs`: `deploy_handler` now uses `SolTemplateEngine` for rendering and `DeployEngine` for Solidity compilation.
  - `deploy_engine.rs`:
    - `solc` executable path is now configurable via `SOLC_PATH` env var (defaults to "solc").
    - `compile_solidity` now takes `base_path` and `remappings` for `solc`.
    - Uses a temporary directory for `solc` compilation outputs.
  - `main.rs` provides `contracts` dir as `base_path` and sets up remapping for OpenZeppelin: `@openzeppelin/contracts/=lib/openzeppelin-repo/contracts/`.
- Project:
  - Added `README.md` to the root directory with project description, prerequisites (including vendorizing OpenZeppelin), and setup/run instructions for backend and frontend.

This prepares the project for your testing of the local compilation flow.